### PR TITLE
Set explicit values and update default access policy

### DIFF
--- a/examples/vault-example/providers.tf
+++ b/examples/vault-example/providers.tf
@@ -3,10 +3,5 @@ terraform {
 }
 
 provider "azurerm" {
-  features {
-    key_vault {
-      recover_soft_deleted_key_vaults = true
-      purge_soft_delete_on_destroy    = false
-    }
-  }
+  features {}
 }

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_key_vault_access_policy" "this" {
   tenant_id    = data.azurerm_client_config.this.tenant_id
   object_id    = data.azurerm_client_config.this.object_id
 
-  secret_permissions = ["Get", "List", "Set", "Delete", "Recover", "Backup", "Restore"]
+  secret_permissions = ["Get", "List", "Set", "Delete", "Recover", "Backup", "Restore", "Purge"]
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,9 @@ resource "azurerm_key_vault" "this" {
   resource_group_name         = var.resource_group_name
   enabled_for_disk_encryption = true
   tenant_id                   = data.azurerm_client_config.this.tenant_id
-  purge_protection_enabled    = false
+
+  soft_delete_retention_days = 90
+  purge_protection_enabled   = false
 
   sku_name = "standard"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,19 @@
 data "azurerm_client_config" "this" {}
 
 resource "azurerm_key_vault" "this" {
-  name                        = var.name
-  location                    = var.location
-  resource_group_name         = var.resource_group_name
-  enabled_for_disk_encryption = true
-  tenant_id                   = data.azurerm_client_config.this.tenant_id
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku_name            = "standard"
+  tenant_id           = data.azurerm_client_config.this.tenant_id
 
   soft_delete_retention_days = 90
   purge_protection_enabled   = false
 
-  sku_name = "standard"
+  enabled_for_deployment          = false
+  enabled_for_disk_encryption     = false
+  enabled_for_template_deployment = false
+  enable_rbac_authorization       = false
 }
 
 resource "azurerm_key_vault_access_policy" "this" {


### PR DESCRIPTION
Set explicit values for several properties, to ensure these are consistent even if HashiCorp were to change the default values for these properties.

Also set secrets "Purge" permission for current client, to add support for using this module without the following Azure provider feature:

```terraform
provider "azurerm" {
  features {
    key_vault {
      purge_soft_delete_on_destroy = false
    }
  }
}
```