### PR TITLE
Add variable for overriding key vault name

### DIFF
--- a/examples/key-vault-with-custom-name/main.tf
+++ b/examples/key-vault-with-custom-name/main.tf
@@ -1,0 +1,37 @@
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = true
+      purge_soft_delete_on_destroy    = false
+    }
+  }
+}
+
+locals {
+  app_name         = "ops-vault"
+  environment_name = "example"
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "rg-${local.app_name}-${local.environment_name}"
+  location = "northeurope"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "log-${local.app_name}-${local.environment_name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "Free"
+}
+
+module "vault" {
+  source = "../.."
+
+  app_name                   = local.app_name
+  environment_name           = local.environment_name
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  key_vault_name = "${local.app_name}-${local.environment_name}-kv"
+}

--- a/examples/key-vault-with-secret/main.tf
+++ b/examples/key-vault-with-secret/main.tf
@@ -1,5 +1,10 @@
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults = true
+      purge_soft_delete_on_destroy    = false
+    }
+  }
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "this" {}
 
 resource "azurerm_key_vault" "this" {
-  name                = "kv-${var.app_name}-${var.environment_name}"
+  name                = coalesce(var.key_vault_name, "kv-${var.app_name}-${var.environment_name}")
   location            = var.location
   resource_group_name = var.resource_group_name
   sku_name            = "standard"

--- a/test/vault_test.go
+++ b/test/vault_test.go
@@ -15,3 +15,13 @@ func TestKeyVaultWithSecret(t *testing.T) {
 
 	terraform.InitAndApply(t, terraformOptions)
 }
+
+func TestKeyVaultWithCustomName(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/key-vault-with-custom-name",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,11 @@
 variable "app_name" {
-  type = string
+  description = "Application name, used to generate resource names"
+  type        = string
 }
 
 variable "environment_name" {
-  type = string
+  description = "Environment name, used to generate resource names"
+  type        = string
 }
 
 variable "location" {
@@ -16,6 +18,12 @@ variable "resource_group_name" {
 
 variable "log_analytics_workspace_id" {
   type = string
+}
+
+variable "key_vault_name" {
+  description = "Key vault name, generated if not set"
+  type        = string
+  default     = null
 }
 
 variable "client_permissions" {


### PR DESCRIPTION
By default, key vault name is generated using the given app name and environment name. We prefer to generate the key vault name in order to follow a common naming convention.

There should however be an optional variable to override the key vault name if desired, so that projects that follow different naming conventions can still benefit from this module.

Additional examples and tests have been added as well.

All tests passed successfully with my changes.