### PR TITLE
refactor: set explicit values for arguments with default values

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "azurerm_key_vault_access_policy" "this" {
   secret_permissions      = var.client_secret_permissions
   certificate_permissions = var.client_certificate_permissions
   key_permissions         = var.client_key_permissions
+  storage_permissions     = []
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {
@@ -43,6 +44,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     enabled  = true
 
     retention_policy {
+      days    = 0
       enabled = false
     }
   }
@@ -52,6 +54,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     enabled  = false
 
     retention_policy {
+      days    = 0
       enabled = false
     }
   }
@@ -61,6 +64,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     enabled  = true
 
     retention_policy {
+      days    = 0
       enabled = false
     }
   }


### PR DESCRIPTION
If some arguments are omitted from the Terraform config, they will be set to a default value by Azure after the infrastructure has been provisioned. These arguments will then be reported as changed outside of Terraform. Set explicit values for arguments with default values to prevent these reports.